### PR TITLE
Default to the portable attention backend on GPUs without FA3 kernels

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,12 @@ PORT=8010 \
 ```
 
 The default `fa3` attention backend is intended for Hopper GPUs such as H20
-and H100. On consumer Blackwell GPUs such as RTX 5090, select FlashInfer for
-the SGLang slow-AR path; the adapter then uses PyTorch SDPA for the short
-fixed-cache fast head:
+and H100. Consumer Blackwell GPUs such as RTX 5090 report compute capability
+`(12, 0)` and have no FA3 kernel image, so the adapter detects them and selects
+FlashInfer for the SGLang slow-AR path automatically; the short fixed-cache
+fast head then uses PyTorch SDPA. No configuration is required.
+
+Setting the variable explicitly still overrides the detection on any GPU:
 
 ```bash
 AUDIO8_TTS_ATTENTION_BACKEND=flashinfer \
@@ -237,7 +240,8 @@ memory fraction, and up to 32 running requests. The main runtime controls are
 `AUDIO8_TTS_DISABLE_CUDA_GRAPH`. When Torch compilation is enabled, the adapter
 uses SGLang's native batch-size policy. Set `AUDIO8_TTS_TORCH_COMPILE_MAX_BS`
 only when an explicit compile limit is needed. `AUDIO8_TTS_ATTENTION_BACKEND`
-defaults to `fa3`; set it to `flashinfer` for consumer Blackwell. Set
+defaults to `fa3`, except on GPUs with no FA3 kernel image such as consumer
+Blackwell, where it defaults to `flashinfer`; set it explicitly to override. Set
 `SGLANG_OMNI_SITE_PACKAGES` when the runtime dependencies are installed in a
 separate site-packages directory.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -201,9 +201,12 @@ PORT=8010 \
 ./sglang_omni/scripts/run_server.sh
 ```
 
-默认的 `fa3` attention backend 适用于 H20、H100 等 Hopper GPU。在 RTX 5090 等消费级
-Blackwell GPU 上，应为 SGLang Slow AR 路径选择 FlashInfer；此时适配器会在短序列固定
-KV cache 的 Fast head 中使用 PyTorch SDPA：
+默认的 `fa3` attention backend 适用于 H20、H100 等 Hopper GPU。RTX 5090 等消费级
+Blackwell GPU 的计算能力为 `(12, 0)`，没有对应的 FA3 kernel image，适配器会自动识别
+并为 SGLang Slow AR 路径选择 FlashInfer；此时短序列固定 KV cache 的 Fast head 会使用
+PyTorch SDPA。无需额外配置。
+
+在任意 GPU 上显式设置该环境变量仍会覆盖自动检测结果：
 
 ```bash
 AUDIO8_TTS_ATTENTION_BACKEND=flashinfer \
@@ -218,8 +221,9 @@ MODEL="${MODEL}" \
 `AUDIO8_TTS_MAX_RUNNING_REQUESTS`、`AUDIO8_TTS_CHUNKED_PREFILL_SIZE` 和
 `AUDIO8_TTS_DISABLE_CUDA_GRAPH`。开启 Torch compile 后，适配器沿用 SGLang 原生的 batch
 策略；只有需要明确限制 compile 上限时才设置 `AUDIO8_TTS_TORCH_COMPILE_MAX_BS`。
-`AUDIO8_TTS_ATTENTION_BACKEND` 默认为 `fa3`；消费级 Blackwell GPU 应设置为
-`flashinfer`。如果运行依赖安装在单独的 site-packages 目录中，请设置
+`AUDIO8_TTS_ATTENTION_BACKEND` 默认为 `fa3`；在没有 FA3 kernel image 的 GPU（如消费级
+Blackwell）上默认为 `flashinfer`，显式设置可覆盖。如果运行依赖安装在单独的
+site-packages 目录中，请设置
 `SGLANG_OMNI_SITE_PACKAGES`。
 
 ### 常见问题

--- a/sglang_omni/OPTIMIZATION_REPORT.md
+++ b/sglang_omni/OPTIMIZATION_REPORT.md
@@ -77,6 +77,13 @@ and uses SDPA with an explicit valid-prefix mask and GQA. Shapes remain static
 for CUDA Graph capture. This avoids the Hopper-only FA3 custom op on `sm_120`
 without changing the Hopper path.
 
+When the variable is unset, the backend is resolved by
+`models/audio8_tts/attention_backend.py`. Devices whose compute capability has
+no FA3 kernel image — currently `(12, 0)`, consumer Blackwell — default to
+`flashinfer`; every other device keeps `fa3`. The probe is cached and runs once
+per process, and an explicit `AUDIO8_TTS_ATTENTION_BACKEND` always takes
+precedence, so Hopper deployments are unaffected.
+
 For consumer Blackwell deployment, `sgl_kernel` also requires the system
 `libnuma` library. The CUDA toolkit `bin` directory must be on `PATH`, and
 `CUDA_PATH` may be required by `deep_gemm` JIT. Transformers must remain in the

--- a/sglang_omni/adapter/sglang_omni/models/audio8_tts/attention_backend.py
+++ b/sglang_omni/adapter/sglang_omni/models/audio8_tts/attention_backend.py
@@ -1,0 +1,66 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Attention backend selection for the Audio8 TTS adapter.
+
+FA3 kernels are built for Hopper only. On devices that ship no FA3 kernel
+image the portable FlashInfer / SDPA path is selected automatically so that a
+default deployment starts without extra configuration. ``fa3`` remains the
+default everywhere else, and an explicit environment override always wins.
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+import os
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+ATTENTION_BACKEND_ENV = "AUDIO8_TTS_ATTENTION_BACKEND"
+DEFAULT_ATTENTION_BACKEND = "fa3"
+PORTABLE_ATTENTION_BACKEND = "flashinfer"
+
+# Consumer Blackwell (RTX 50 series) reports compute capability (12, 0) and has
+# no FA3 kernel image, so flash_attn_with_kvcache fails at launch with
+# "no kernel image is available for execution on the device".
+_CAPABILITIES_WITHOUT_FA3 = frozenset({(12, 0)})
+
+
+def _device_capability() -> Optional[Tuple[int, int]]:
+    try:
+        import torch
+
+        if not torch.cuda.is_available():
+            return None
+        return torch.cuda.get_device_capability()
+    except Exception:  # never block startup on a probe
+        logger.debug("Could not query CUDA compute capability", exc_info=True)
+        return None
+
+
+@functools.lru_cache(maxsize=1)
+def fa3_kernels_available() -> bool:
+    """Whether the current device is expected to have an FA3 kernel image."""
+    capability = _device_capability()
+    if capability is None:
+        return True
+    if capability in _CAPABILITIES_WITHOUT_FA3:
+        logger.info(
+            "Compute capability %s has no FA3 kernel image; defaulting to the "
+            "'%s' attention backend. Set %s to override.",
+            capability,
+            PORTABLE_ATTENTION_BACKEND,
+            ATTENTION_BACKEND_ENV,
+        )
+        return False
+    return True
+
+
+def resolve_attention_backend() -> str:
+    """Return the attention backend name, honouring the environment override."""
+    override = os.getenv(ATTENTION_BACKEND_ENV)
+    if override:
+        return override.lower()
+    if fa3_kernels_available():
+        return DEFAULT_ATTENTION_BACKEND
+    return PORTABLE_ATTENTION_BACKEND

--- a/sglang_omni/adapter/sglang_omni/models/audio8_tts/factory.py
+++ b/sglang_omni/adapter/sglang_omni/models/audio8_tts/factory.py
@@ -7,6 +7,11 @@ from typing import Any
 
 from sglang_omni.engines.omni.engine import OmniEngine
 from sglang_omni.engines.omni.scheduler import Scheduler
+from sglang_omni.models.audio8_tts.attention_backend import (
+    ATTENTION_BACKEND_ENV,
+    PORTABLE_ATTENTION_BACKEND,
+    fa3_kernels_available,
+)
 from sglang_omni.models.audio8_tts.runtime.audio8_sglang_ar import (
     Audio8IterationController,
     Audio8ModelRunner,
@@ -131,7 +136,11 @@ def make_server_args(model_path: str) -> Any:
     torch_compile_max_bs = os.getenv("AUDIO8_TTS_TORCH_COMPILE_MAX_BS")
     if torch_compile_max_bs is not None:
         server_args.torch_compile_max_bs = int(torch_compile_max_bs)
-    attention_backend = os.getenv("AUDIO8_TTS_ATTENTION_BACKEND")
+    attention_backend = os.getenv(ATTENTION_BACKEND_ENV)
+    if attention_backend is None and not fa3_kernels_available():
+        # No FA3 kernel image on this device; pick the portable backend rather
+        # than leaving SGLang to fail at kernel launch.
+        attention_backend = PORTABLE_ATTENTION_BACKEND
     if attention_backend:
         server_args.attention_backend = attention_backend
     return server_args

--- a/sglang_omni/adapter/sglang_omni/models/audio8_tts/sglang_model.py
+++ b/sglang_omni/adapter/sglang_omni/models/audio8_tts/sglang_model.py
@@ -23,6 +23,7 @@ from sglang_omni.vendor.sglang.layers import (
     VocabParallelEmbedding,
     get_rope,
 )
+from sglang_omni.models.audio8_tts.attention_backend import resolve_attention_backend
 from sglang_omni.vendor.sglang.models import apply_qk_norm
 from sglang_omni.vendor.sglang.utils import make_layers
 
@@ -41,7 +42,7 @@ def _audio8_fast_attention_with_cache(
     value: Tensor,
     cache_positions: Tensor,
 ) -> Tensor:
-    attention_backend = os.getenv("AUDIO8_TTS_ATTENTION_BACKEND", "fa3").lower()
+    attention_backend = resolve_attention_backend()
     if attention_backend == "fa3":
         return flash_attn_with_kvcache(
             q=query,


### PR DESCRIPTION
Follow-up to #8 / #9. You mentioned a PR would be welcome for auto-selecting the SDPA path on `(12, 0)`, so here it is.

## What this changes

`AUDIO8_TTS_ATTENTION_BACKEND` keeps `fa3` as its default. The only new behaviour is that when the variable is **unset** and the device has no FA3 kernel image, the resolved default becomes `flashinfer` instead. An explicit setting always wins, on every GPU.

Backend resolution moves into `models/audio8_tts/attention_backend.py`, used by both existing read sites:

- `sglang_model.py` — the fixed-cache fast head
- `factory.py` — `server_args.attention_backend`

The probe is `functools.lru_cache`d, so it runs once per process and the custom op stays a dict lookup on the hot path. If the probe raises for any reason it returns `fa3`, so no failure mode is worse than today.

## Why the current default still fails on sm_120

Worth being precise, since it is narrower than it first looks. With the variable unset on consumer Blackwell, SGLang's own logic already picks FlashInfer for the slow-AR path:

```
sglang.srt.server_args: Attention backend not specified. Use flashinfer backend by default.
```

The slow-AR path is therefore fine. What fails is the **fast head**, which independently defaults to `"fa3"` and calls `flash_attn_with_kvcache` during CUDA graph capture:

```
Capturing batches (bs=8 avail_mem=12.20 GB):   0%|          | 0/4
CUDA error (_deps/repo-flash-attention-src/hopper/flash_fwd_launch_template.h:166):
no kernel image is available for execution on the device
```

That reproduces on current `master` (`f52c66a`) about nine seconds into startup. So the `sglang_model.py` change is the actual fix; the `factory.py` change only makes the two sites agree rather than relying on SGLang's default happening to match.

## Verification

Measured on an RTX 5090 Laptop GPU (sm_120, 24 GB), torch 2.9.1+cu128, sglang 0.5.8, transformers 4.57.1, against `master` at `f52c66a`.

| Case | Before this PR | After this PR |
|---|---|---|
| env unset, sm_120 | fails at ~9 s, no-kernel-image during graph capture | **healthy in 12 s** |
| env unset, sm_120 — synthesis | — | HTTP 200, 44.1 kHz mono PCM_16, 6.32 s |
| env unset, sm_120 — ASR check | — | **verbatim** |
| env `=fa3`, sm_120 | SGLang asserts `SM>=80 and SM<=90` | identical — override respected |
| env `=flashinfer`, sm_120 | works | identical |

The generated audio was ASR-checked rather than eyeballed. `Order 47 ships on March 3rd at 9 a.m. from Dr. Chen on Route 66.` came back as *"Order forty seven ships on March third at nine a.m. from Doctor Chen on Route sixty six"*, so the #15 normalization path is intact.

Resolution logic, with the capability probe stubbed:

```
PASS  cap=(9, 0)    env=None         -> fa3          # Hopper, unchanged
PASS  cap=(8, 9)    env=None         -> fa3          # Ada, unchanged
PASS  cap=(10, 0)   env=None         -> fa3          # datacenter Blackwell, unchanged
PASS  cap=(12, 0)   env=None         -> flashinfer   # the fix
PASS  cap=None      env=None         -> fa3          # probe failed, fail safe
PASS  cap=(12, 0)   env=fa3          -> fa3          # override wins
PASS  cap=(9, 0)    env=flashinfer   -> flashinfer   # override wins
PASS  cap=(12, 0)   env=FlashInfer   -> flashinfer   # override lowercased
```

## One deliberate choice

`_CAPABILITIES_WITHOUT_FA3` lists only `(12, 0)` — exactly what was discussed, and the only capability we can test here. Datacenter Blackwell `(10, 0)` and GB10 may well have the same gap, but we have no way to confirm that, and guessing would risk changing behaviour on hardware we cannot verify. Adding a capability later is a one-line change to that frozenset.

Docs updated in `README.md`, `README_zh.md`, and `OPTIMIZATION_REPORT.md`. Happy to adjust anything here, including dropping the `factory.py` half if you would rather keep the change to the single site that actually breaks.
